### PR TITLE
Remove unused #uri= in Scraper

### DIFF
--- a/lib/funky/scraper.rb
+++ b/lib/funky/scraper.rb
@@ -2,8 +2,8 @@ module Funky
   class Scraper
     attr_reader :uri
 
-    def initialize(uri = nil)
-      @uri = URI uri if uri
+    def initialize(uri)
+      @uri = URI uri
     end
 
     def shares
@@ -16,19 +16,9 @@ module Funky
       $1 ? $1.delete(',').to_i : nil
     end
 
-    def uri=(uri)
-      reset_response
-      @uri = URI uri
-    end
-
   private
 
-    def reset_response
-      @response = nil
-    end
-
     def response
-      raise "URI needs to be set" unless uri
       @response ||= Net::HTTP.get(uri)
     end
   end


### PR DESCRIPTION
Before it was optional to pass the URI during Scraper instantiation, so it was possible to set the URI using `#uri=`.

That is no longer the case. Instantiation of Scraper will require a URI
