### PR TITLE
Add a test to ensure bad video ids are ignored

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@ Under the hood, Funky hits FB's APIs on most cases, while other cases it will sc
 
 ## Usage
 
-Right now it can only be used to get basic count data of Facebook videos.
+Right now it can only be used to get certain data of Facebook videos.
 
 ```ruby
 ids = ['10154439119663508', '10153834590672139']
 videos = Funky::Video.where(ids: ids)
+videos.first.id            #=> '10154439119663508'
 videos.first.like_count    #=> 1169
 videos.first.comment_count #=> 65
 videos.first.share_count   #=> 348
@@ -17,6 +18,16 @@ videos.first.created_time  #=> #<DateTime: 2015-12-17T06:29:48+00:00>
 videos.first.description   #=> "Hugh Jackman coaches Great Britain's..."
 videos.first.length        #=> 147.05
 
+```
+
+If a non-existing video ID is passed into the where clause, it is ignored. Other video IDs will still be retrieved.
+
+```ruby
+ids = ['10154439119663508', '10153834590672139', 'doesnotexist']
+videos = Funky::Video.where(ids: ids)
+videos.count    #=> 2
+videos.first.id #=> '10154439119663508'
+videos.last.id  #=> '10153834590672139'
 ```
 
 ## Development

--- a/spec/videos/video_spec.rb
+++ b/spec/videos/video_spec.rb
@@ -48,11 +48,23 @@ describe 'Video' do
         '903078593095780', '1042754339128204', '1041643712572600',
         '1042056582531313','1042669312451336']
     end
+    let(:multiple_video_ids_with_one_bad) do
+      multiple_video_ids + ['doesnotexist']
+    end
     let(:videos) { Funky::Video.where(ids: multiple_video_ids) }
+    let(:videos_with_a_bad_id) do
+      Funky::Video.where(ids: multiple_video_ids_with_one_bad)
+    end
 
     context 'given multiple existing video IDs were passed' do
       specify 'returns one video for each id, in the same order provided' do
         expect(videos.map &:id).to eq(multiple_video_ids)
+      end
+    end
+
+    context 'given a non-existing video id passed with other video ids' do
+      specify 'returns only the existing videos' do
+        expect(videos_with_a_bad_id.map &:id).to eq(multiple_video_ids)
       end
     end
   end


### PR DESCRIPTION
If bad ids are passed along with good video ids in Video.where(ids: ids), it will return only the videos with good ids.
