### PR TITLE
Raise Funky::ConnectionError if unable to connect.

### DIFF
--- a/lib/funky/errors.rb
+++ b/lib/funky/errors.rb
@@ -1,4 +1,4 @@
 module Funky
-  class ContentNotFound < StandardError
-  end
+  class ContentNotFound < StandardError; end
+  class ConnectionError < StandardError; end
 end

--- a/lib/funky/scraper.rb
+++ b/lib/funky/scraper.rb
@@ -4,6 +4,8 @@ module Funky
 
     def initialize(uri)
       @response ||= Net::HTTP.get(URI uri)
+    rescue SocketError => e
+      raise ConnectionError, e.message
     end
 
     def shares

--- a/lib/funky/video.rb
+++ b/lib/funky/video.rb
@@ -102,6 +102,8 @@ module Funky
           end
         end
       end.compact
+    rescue Faraday::ConnectionFailed => e
+      raise ConnectionError, e.message
     end
 
     def self.instantiate_collection(items)


### PR DESCRIPTION
So far, I've identified SocketError and Faraday::ConnectionFailed being two
errors that are raised when connection has failed.

Funky we rescue those and raise Funky::ConnectionError.
