### PR TITLE
Failing test: video with cumulative views

### DIFF
--- a/spec/videos/video_spec.rb
+++ b/spec/videos/video_spec.rb
@@ -70,6 +70,12 @@ describe 'Video' do
       it { expect {video}.to raise_error(Funky::ContentNotFound) }
     end
 
+    context 'given a video ID with the cumulative views was passed' do
+      let(:video_id) { '203203106739575' }
+
+      it { expect(video.view_count).to be_an(Integer) }
+    end
+
     context 'given a SocketError' do
       let(:video_id) { existing_video_id }
       let(:socket_error) { SocketError.new }


### PR DESCRIPTION
Facebook is gradually changing the HTML of the video pages so that
views are displayed cumulatively in a pop-up. For example:

https://www.facebook.com/video.php?v=203203106739575

Unfortunately this breaks Funky.
And unfortunately this is not for **every** video (yet?) so we have
to be able to parse both the new and old HTML.

This PR simply adds a test to show the error in Travis.