### PR TITLE
Always return 'views from this post' in view_count

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,9 @@ rvm:
   - 2.3.1
 before_install: gem install bundler -v 1.12.3
 script: bundle exec rspec spec
+# Note: environment variables are NOT accessible for PRs created from forks.
+# Therefore PRs from forks will fail until the following issue is closed:
+# https://github.com/travis-ci/travis-ci/issues/1946
+env:
+  global:
+    secure: Ru7XMnp+0D3tqXJJKRivQHA/e76dhUS4zv9SAvcyzTeuELtn41PQ07r53lunz2t6btXuyRy5Cyr9DD7CnP+ocXbe7Ce6pl5i5gZ7R5KIeWgxZLtKQ5xNs39Yb1jP7RqpgwQFfM86ByQ65zVBKYIRXmDdVfJoG6GM+TeXz6gi3AHwkRmvzSuS5KQ/61GZ8gr6sD55aR1x/YNBsubR7VmKFOmRGAt8XcUND+ArHiDe4mBolKF8d+jYI7a5csDT6ewD5RyT5HOgi0mKobCntvnLQJ4OnCzLjZfihfaw/Dwdp1Ifr6wdvZDB6JtBCxHncOxQ+0oHWEHhzIWHgN1mSmx5CI08J6Hty1nNNF2rgUUdLjh9sYE51QcGWdtCQY5WdYJ2ttGWNhaNFeJR9LPtE+MN3vUtMh0aroCR4g9hs4aLxpcSbdkTlctkMoGuGV2yuFx4R+8CFkReuZNo2t87MophSXo09eEwFE92Nq1S0DrPOzN+IFAy/XhZKnKWHfA7Oi065HlOZ+N7vOQIEVfxrni1mKLarzqDfPGgR/rbwEq7i1YJqBChZU8WXb6ncnkI/bSpurStgz+2+PdSCFNFSmw/s4CPPeiqNPcXM5Z00GlOXkHJ8PkUnc9AhdKb0tfmeU6jC4CX3r9ScFMwTWFU7MfxcFRZ5z+aeaMM5ejqgkueu10=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.2.0  - 2016/06/07
+
+**How to upgrade**
+
+If your code never calls `Funky::Video#view_count`, then you are good to go.
+
+If it does, then be aware that Facebook has started displaying two types of
+view counts in the video page: 'views from this post' and 'cumulative views'.
+For coherence with the videos without this new type of page, `view_count` will
+always return the "views from this post" (whereas it was returning cumulative
+views in 0.1.1)
+
+* [ENHANCEMENT] Always return 'views from this post' in `Funky::Video#view_count`.
+
 ## 0.1.1  - 2016/06/07
 
 * [BUGFIX] Added support for scraping view count from the new cumulative views that Facebook recently started rolling out.

--- a/lib/funky/html/parser.rb
+++ b/lib/funky/html/parser.rb
@@ -18,7 +18,7 @@ module Funky
 
       def extract_views_from(html)
         html.match(/<div><\/div><span class="fcg">(.*) Views<\/span>/)
-        html.match(/id="u_0_n">(.*?) Views/) if $1.nil?
+        html.match %r{([\d,]*?) views from this post} if $1.nil?
         matched_count $1
       end
 

--- a/lib/funky/version.rb
+++ b/lib/funky/version.rb
@@ -1,3 +1,3 @@
 module Funky
-  VERSION = "0.1.1"
+  VERSION = "0.2.0"
 end

--- a/lib/funky/video.rb
+++ b/lib/funky/video.rb
@@ -113,7 +113,7 @@ module Funky
           [body]
         end
       else
-        raise ContentNotFound, 'Please check IDs'
+        raise ContentNotFound, "Error #{response.code}: #{response.body}"
       end
     end
 

--- a/spec/videos/video_spec.rb
+++ b/spec/videos/video_spec.rb
@@ -73,7 +73,9 @@ describe 'Video' do
     context 'given a video ID with the cumulative views was passed' do
       let(:video_id) { '203203106739575' }
 
-      it { expect(video.view_count).to be_an(Integer) }
+      it 'only returns the views from this post (not cumulative ones)' do
+        expect(video.view_count).to be > 50_000_000
+      end
     end
 
     context 'given a SocketError' do


### PR DESCRIPTION
Closes #41 

Same as #41 except that the PR is from origin, not from a fork.

Just an experiment to see whether Travis only reads environment variables in PR from origin, since in #41 I cannot manage to have the FB ENV used by Travis.