### PR TITLE
Find by url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.2.1  - 2016/06/16
+
+* [FEATURE] Add method to find video by url, `Funky::Video.find_by_url!(url)`.
+The following URL formats are currently supported:
+- `https://www.facebook.com/{page_name}/videos/vb.{alt_page_id}/{video_id}/`
+- `https://www.facebook.com/{page_name}/videos/{video_id}/`
+- `https://www.facebook.com/{page_id}/videos/{video_id}/`
+- `https://www.facebook.com/video.php?v={video_id}`
+
 ## 0.2.0  - 2016/06/07
 
 **How to upgrade**

--- a/README.md
+++ b/README.md
@@ -94,6 +94,32 @@ If a non-existing video ID is passed into #find, Funky::ContentNotFound will be 
 Funky::Video.find('doesnotexist') # => raises Funky::ContentNotFound
 ```
 
+### Use #find_by_url!(url) to get a single video from a url
+
+```ruby
+video = Funky::Video.find_by_url!('https://www.facebook.com/video.php?v=10154439119663508')
+video.id            # => '10154439119663508'
+video.like_count    # => 1169
+video.comment_count # => 65
+video.share_count   # => 348
+video.view_count    # => 10121
+```
+
+If a non-existing video url is passed into #find_by, Funky::ContentNotFound will be raised.
+
+```ruby
+Funky::Video.find_by_url!('https://www.facebook.com/video.php?v=doesnotexist')
+  # => raises Funky::ContentNotFound
+```
+
+The current URL formats are supported:
+
+- `https://www.facebook.com/{page_name}/videos/vb.{alt_page_id}/{video_id}`
+- `https://www.facebook.com/{page_name}/videos/{video_id}`
+- `https://www.facebook.com/{page_id}/videos/{video_id}`
+- `https://www.facebook.com/video.php?v={video_id}`
+
+
 ### Connection error
 
 Should there be a case where Funky is unable to connect to Facebook, `Funky::ConnectionError` will be raised.

--- a/lib/funky/url.rb
+++ b/lib/funky/url.rb
@@ -1,0 +1,19 @@
+module Funky
+  class URL
+    attr_reader :url
+    VIDEO_ID_REGEXES = [/videos\/(\d*)/i, /v=(\d*)/i, /vb\..*\/(\d*)/i]
+
+    def initialize(url)
+      @url = url
+    end
+
+    def video_id
+      return unless url.include? 'facebook.com'
+      VIDEO_ID_REGEXES.each do |regex|
+        url.match regex
+        return $1 unless $1.nil? || $1.empty? || !$1.size.between?(15,17)
+      end
+      nil
+    end
+  end
+end

--- a/lib/funky/url.rb
+++ b/lib/funky/url.rb
@@ -1,7 +1,7 @@
 module Funky
   class URL
     attr_reader :url
-    VIDEO_ID_REGEXES = [/videos\/(\d*)/i, /v=(\d*)/i, /vb\..*\/(\d*)/i]
+    VIDEO_ID_REGEXES = [/videos\/(\d*)/i, /v=(\d*)/i, /\/v.\..*\/(\d*)\b/i]
 
     def initialize(url)
       @url = url

--- a/lib/funky/version.rb
+++ b/lib/funky/version.rb
@@ -1,3 +1,3 @@
 module Funky
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/lib/funky/video.rb
+++ b/lib/funky/video.rb
@@ -1,5 +1,6 @@
 require 'funky/html/page'
 require 'funky/html/parser'
+require 'funky/url'
 
 module Funky
   class Video
@@ -88,6 +89,21 @@ module Funky
     def self.find(video_id)
       counters = @@html_parser.parse html: @@html_page.get(video_id: video_id)
       new counters.merge(id: video_id)
+    end
+
+    # Similar to #find, but it finds the video by url instead of video id.
+    # Fetches the data from Facebook's HTML and instantiates the data
+    # into a single Funky::Video object. It can accept one only video url.
+    #
+    # @example Getting a video by url
+    #   url = 'https://www.facebook.com/video.php?v=203203106739575'
+    #   Funky::Video.find_by_url!(url) # => #<Funky::Video>
+    #
+    # @return [Funky::Video] the data scraped from Facebook's HTML
+    #   and encapsulated into a Funky::Video object.
+    def self.find_by_url!(url)
+      url = URL.new(url)
+      find(url.video_id)
     end
 
   private

--- a/spec/url_spec.rb
+++ b/spec/url_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe Funky::URL do
+  let(:video_id) { '965037490222386' }
+
+  def parses(text)
+    url = Funky::URL.new text
+    expect(url.video_id).to eq(video_id)
+  end
+
+  it 'parses any valid URL format for a Facebook video' do
+    # Possible formats
+    parses "facebook.com/PAGE_NAME/videos/vb.PAGE_ID/#{video_id}"
+    parses "facebook.com/PAGE_NAME/videos/#{video_id}"
+    parses "facebook.com/PAGE_ID/videos/#{video_id}"
+    parses "facebook.com/video.php?v=#{video_id}"
+
+    # Possible variants
+    parses "facebook.com/video.php?v=#{video_id}/"
+    parses "www.facebook.com/video.php?v=#{video_id}"
+    parses "http://facebook.com/video.php?v=#{video_id}"
+    parses "https://facebook.com/video.php?v=#{video_id}"
+    parses "http://www.facebook.com/video.php?v=#{video_id}"
+    parses "https://wwwfacebook.com/video.php?v=#{video_id}"
+  end
+end

--- a/spec/url_spec.rb
+++ b/spec/url_spec.rb
@@ -11,16 +11,18 @@ describe Funky::URL do
   it 'parses any valid URL format for a Facebook video' do
     # Possible formats
     parses "facebook.com/PAGE_NAME/videos/vb.PAGE_ID/#{video_id}"
+    parses "facebook.com/PAGE_NAME/videos/vl.PAGE_ID/#{video_id}"
     parses "facebook.com/PAGE_NAME/videos/#{video_id}"
     parses "facebook.com/PAGE_ID/videos/#{video_id}"
     parses "facebook.com/video.php?v=#{video_id}"
 
     # Possible variants
+    parses "facebook.com/PAGE_NAME/videos/vl.PAGE_ID/#{video_id}/?type=1"
     parses "facebook.com/video.php?v=#{video_id}/"
     parses "www.facebook.com/video.php?v=#{video_id}"
     parses "http://facebook.com/video.php?v=#{video_id}"
     parses "https://facebook.com/video.php?v=#{video_id}"
     parses "http://www.facebook.com/video.php?v=#{video_id}"
-    parses "https://wwwfacebook.com/video.php?v=#{video_id}"
+    parses "https://www.facebook.com/video.php?v=#{video_id}"
   end
 end

--- a/spec/videos/shared/examples.rb
+++ b/spec/videos/shared/examples.rb
@@ -1,0 +1,25 @@
+shared_examples 'check id and counters' do
+  it { expect(video.id).to be_a(String) }
+  it { expect(video.like_count).to be_an(Integer) }
+  it { expect(video.comment_count).to be_an(Integer) }
+  it { expect(video.share_count).to be_an(Integer) }
+  it { expect(video.view_count).to be_an(Integer) }
+end
+
+shared_examples 'socket error' do
+  let(:socket_error) { SocketError.new }
+
+  before { expect(Net::HTTP).to(receive(:start).and_raise socket_error) }
+
+  it { expect { video }.to raise_error(Funky::ConnectionError) }
+end
+
+shared_examples 'cumulative views' do
+  it 'only returns the views from this post (not cumulative ones)' do
+    expect(video.view_count).to be > 50_000_000
+  end
+end
+
+shared_examples 'non-existing video' do
+  it { expect {video}.to raise_error(Funky::ContentNotFound) }
+end

--- a/spec/videos/video_spec.rb
+++ b/spec/videos/video_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'videos/shared/examples'
 
 describe 'Video' do
   let(:existing_video_id) { '1042790765791228' }
@@ -57,34 +58,55 @@ describe 'Video' do
     context 'given an existing video ID was passed' do
       let(:video_id) { existing_video_id }
 
-      it { expect(video.id).to be_a(String) }
-      it { expect(video.like_count).to be_an(Integer) }
-      it { expect(video.comment_count).to be_an(Integer) }
-      it { expect(video.share_count).to be_an(Integer) }
-      it { expect(video.view_count).to be_an(Integer) }
+      include_examples 'check id and counters'
     end
 
     context 'given a non-existing video ID was passed' do
       let(:video_id) { unknown_video_id }
 
-      it { expect {video}.to raise_error(Funky::ContentNotFound) }
+      include_examples 'non-existing video'
     end
 
     context 'given a video ID with the cumulative views was passed' do
       let(:video_id) { '203203106739575' }
 
-      it 'only returns the views from this post (not cumulative ones)' do
-        expect(video.view_count).to be > 50_000_000
-      end
+      include_examples 'cumulative views'
     end
 
     context 'given a SocketError' do
       let(:video_id) { existing_video_id }
-      let(:socket_error) { SocketError.new }
 
-      before { expect(Net::HTTP).to(receive(:start).and_raise socket_error) }
+      include_examples 'socket error'
+    end
+  end
 
-      it { expect { video }.to raise_error(Funky::ConnectionError) }
+  describe '.find_by_url!(url)' do
+    let(:video) {Funky::Video.find_by_url! url}
+
+    context "given an existing video url" do
+      let(:video_id) { '965037490222386' }
+      let(:url) { "facebook.com/videos.php?v=#{video_id}" }
+
+      include_examples 'check id and counters'
+    end
+
+
+    context 'given a non-existing video url was passed' do
+      let(:url) { 'https://www.facebook.com/video.php?v=doesnotexist'}
+
+      include_examples 'non-existing video'
+    end
+
+    context 'given a video url with cumulative views was passed' do
+      let(:url) { 'https://www.facebook.com/video.php?v=203203106739575' }
+
+      include_examples 'cumulative views'
+    end
+
+    context 'given a SocketError' do
+      let(:url) { 'https://www.facebook.com/video.php?v=1559182744389118' }
+
+      include_examples 'socket error'
     end
   end
 end


### PR DESCRIPTION
`Video#find_by_url!(url)` will fetch the video based on a URL that was passed. It first parses the url to find the video_id, then it passes the video_id to `Video#find(video_id)`.

Supported url formats:
`https://www.facebook.com/{account_name}/videos/vb.{alt_account_id}/{video_id}/`
`https://www.facebook.com/{account_name}/videos/{video_id}/`
`https://www.facebook.com/{account_id}/videos/{video_id}/`
`https://www.facebook.com/video.php?v={video_id}`