### PR TITLE
`Funky::Video.where(id: id)` should never error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.2.2 - 2016/06/17
+
+* [BUGFIX] Single video id passed to the `Funky::Video.where` clause will not
+error even if the response is not 200. It would return an empty array.
+
 ## 0.2.1  - 2016/06/16
 
 * [FEATURE] Add method to find video by url, `Funky::Video.find_by_url!(url)`.

--- a/lib/funky/version.rb
+++ b/lib/funky/version.rb
@@ -1,3 +1,3 @@
 module Funky
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 end

--- a/lib/funky/video.rb
+++ b/lib/funky/video.rb
@@ -116,6 +116,8 @@ module Funky
         response = Connection::API.request(id: id, fields: fields)
       end
       parse response
+    rescue ContentNotFound
+      []
     end
 
     def self.parse(response)

--- a/spec/videos/video_spec.rb
+++ b/spec/videos/video_spec.rb
@@ -22,9 +22,8 @@ describe 'Video' do
 
     context 'given one unknown video ID was passed' do
       let(:video_ids) {unknown_video_id}
-      let(:video) {videos.first}
 
-      it { expect{video.id}.to raise_error(Funky::ContentNotFound) }
+      it { expect(videos).to be_empty }
     end
 
     context 'given multiple existing video IDs were passed' do


### PR DESCRIPTION
Before, if a single video id was passed into Funky::Video.where,
and that video could not be accessed, it would raise ContentNotFound.
That goes against the readme and is not consistent with when we pass
multiple ids to the where clause. The where clause should simply
ignore badd video ids. If it's a single video id, it should return
and empty array.