### PR TITLE
Add page_name attribute for a video from API call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.2.3 - 2016/06/22
+
+* [FEATURE] Add `page_name` of a video found by API call (which is `Funky::Video.where`)
+
 ## 0.2.2 - 2016/06/17
 
 * [BUGFIX] Single video id passed to the `Funky::Video.where` clause will not

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ videos.first.created_time  # => #<DateTime: 2015-12-17T06:29:48+00:00>
 videos.first.description   # => "Hugh Jackman coaches Great Britain's..."
 videos.first.length        # => 147.05
 videos.first.picture       # => "https://scontent.xx.fbcdn.net/v/..."
+videos.first.page_name     # => "Moviefone"
 
 ```
 

--- a/lib/funky/version.rb
+++ b/lib/funky/version.rb
@@ -1,3 +1,3 @@
 module Funky
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end

--- a/lib/funky/video.rb
+++ b/lib/funky/video.rb
@@ -40,6 +40,11 @@ module Funky
       data[:picture]
     end
 
+    # @return [String] the name of Facebook page for the video.
+    def page_name
+      data.fetch(:from)[:name]
+    end
+
     # @return [Integer] the total number of likes for the video.
     def like_count
       data[:like_count]
@@ -144,6 +149,7 @@ module Funky
         'created_time',
         'description',
         'length',
+        'from',
         'picture'
       ]
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 require 'simplecov'
 require 'coveralls'
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new [
   SimpleCov::Formatter::HTMLFormatter,
   Coveralls::SimpleCov::Formatter
 ]

--- a/spec/videos/video_spec.rb
+++ b/spec/videos/video_spec.rb
@@ -18,6 +18,7 @@ describe 'Video' do
       it { expect(video.description).to be_a(String) }
       it { expect(video.length).to be_a(Float) }
       it { expect(video.picture).to be_a(String)}
+      it { expect(video.page_name).to be_a(String) }
     end
 
     context 'given one unknown video ID was passed' do


### PR DESCRIPTION
```rb
Funky::Video.where(id: '203203106739575').first.page_name
# => "This Is Us"
```
close #46 