### PR TITLE
Capture view count while being language agnostic

### DIFF
--- a/lib/funky/html/parser.rb
+++ b/lib/funky/html/parser.rb
@@ -17,7 +17,7 @@ module Funky
       end
 
       def extract_views_from(html)
-        html.match(/<div><\/div><span class="fcg">(.*) Views<\/span>/)
+        html.match(/<div><\/div><span class="fcg">\D*([,0-9]+)/)
         html.match %r{([\d,]*?) views from this post} if $1.nil?
         matched_count $1
       end


### PR DESCRIPTION
Before we depended the capture on view count being located between
`<span class="fcg">` and `Views`. Obviously, `Views` is English,
making it language dependent. So we changed the regex to look for
numbers after `<span class="fcg">` instead, which should be
language agnostic for the most part.

I tested 241 videos with the old regex, and the same 241 videos with this new regex, and the results are consistent. I also did a test with the sample hebrew html that was provided from #47 and ran it against this regex, and it got the view count. 

This should fix #47 

@claudiob, what do you think?