### PR TITLE
Dot separators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.2.5 - 2016/07/25
+
+* [ENHANCEMENT] Allow Funky to also scrape view count that uses dot delimiters. Previously, it only scraped view count with comma delimiters.
+
 ## 0.2.4 - 2016/06/28
 
 * [ENHANCEMENT] Change the way views are scraped from a Facebook page, by not depending the regex on the word "Views". This has the added benefit of being able to scrape the Facebook pages that are not just in English, but also in Hebrew. Potentially, it could scrape from other languages too, but that is  speculation for now.

--- a/lib/funky/html/parser.rb
+++ b/lib/funky/html/parser.rb
@@ -17,8 +17,8 @@ module Funky
       end
 
       def extract_views_from(html)
-        html.match(/<div><\/div><span class="fcg">\D*([,0-9]+)/)
-        html.match %r{([\d,]*?) views from this post} if $1.nil?
+        html.match(/<div><\/div><span class="fcg">\D*([\d,.]+)/)
+        html.match %r{([\d,.]*?) views from this post} if $1.nil?
         matched_count $1
       end
 

--- a/lib/funky/version.rb
+++ b/lib/funky/version.rb
@@ -1,3 +1,3 @@
 module Funky
-  VERSION = "0.2.4"
+  VERSION = "0.2.5"
 end


### PR DESCRIPTION
Previously, if the view count display on FB's html used dot delimiters instead of comma delimiters, it would have failed to scrape the correct view count.

Previous behavior:
If view count was 13.157.371, Funky would return 13.
It fails to match past the dot.

New behavior:
If view count is 13.157.371, Funky would return 13157371
Just like if view count is 13,157,371, which Funky would return 13157371

@claudiob, what do you think?