### PR TITLE
Rescue more errors and raise ConnectionError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.2.7 - 2016/08/18
+
+* [ENHANCEMENT] When Funky makes a request to an HTML page, Funky would now raise `Funky::ConnectionError` should the following errors occur:
+OpenSSL::SSL::SSLError,
+Errno::ETIMEDOUT,
+Errno::EHOSTUNREACH,
+Errno::ENETUNREACH,
+Errno::ECONNRESET,
+Net::OpenTimeout,
+SocketError
+
 ## 0.2.6 - 2016/08/05
 
 * [BUGFIX] Force scraping to use English-US version of Facebook by appending `locale=en_US` to the query string. This prevents cases where Funky's requests originate from non English speaking countries and receiving different HTML templates.

--- a/lib/funky/html/page.rb
+++ b/lib/funky/html/page.rb
@@ -19,7 +19,7 @@ module Funky
         Net::HTTP.start(uri.host, 443, use_ssl: true) do |http|
           http.request request
         end
-      rescue SocketError => e
+      rescue *server_errors => e
         raise ConnectionError, e.message
       end
 
@@ -27,6 +27,18 @@ module Funky
         URI::HTTPS.build host:  'www.facebook.com',
                          path:  '/video.php',
                          query: "v=#{video_id}&locale=en_US"
+      end
+
+      def server_errors
+        [
+          OpenSSL::SSL::SSLError,
+          Errno::ETIMEDOUT,
+          Errno::EHOSTUNREACH,
+          Errno::ENETUNREACH,
+          Errno::ECONNRESET,
+          Net::OpenTimeout,
+          SocketError
+        ]
       end
     end
   end

--- a/lib/funky/version.rb
+++ b/lib/funky/version.rb
@@ -1,3 +1,3 @@
 module Funky
-  VERSION = "0.2.6"
+  VERSION = "0.2.7"
 end

--- a/spec/videos/shared/examples.rb
+++ b/spec/videos/shared/examples.rb
@@ -6,12 +6,23 @@ shared_examples 'check id and counters' do
   it { expect(video.view_count).to be_an(Integer) }
 end
 
-shared_examples 'socket error' do
-  let(:socket_error) { SocketError.new }
-
-  before { expect(Net::HTTP).to(receive(:start).and_raise socket_error) }
-
-  it { expect { video }.to raise_error(Funky::ConnectionError) }
+shared_examples 'server errors' do
+  server_errors = [
+                    OpenSSL::SSL::SSLError,
+                    Errno::ETIMEDOUT,
+                    Errno::EHOSTUNREACH,
+                    Errno::ENETUNREACH,
+                    Errno::ECONNRESET,
+                    Net::OpenTimeout,
+                    SocketError
+                  ]
+  server_errors.each do |server_error|
+    context "given #{server_error.to_s}" do
+      let(:error) { server_error.new }
+      before { expect(Net::HTTP).to(receive(:start).and_raise error) }
+      it { expect { video }.to raise_error(Funky::ConnectionError) }
+    end
+  end
 end
 
 shared_examples 'cumulative views' do

--- a/spec/videos/video_spec.rb
+++ b/spec/videos/video_spec.rb
@@ -73,10 +73,10 @@ describe 'Video' do
       include_examples 'cumulative views'
     end
 
-    context 'given a SocketError' do
+    context 'given server errors' do
       let(:video_id) { existing_video_id }
 
-      include_examples 'socket error'
+      include_examples 'server errors'
     end
   end
 
@@ -103,10 +103,10 @@ describe 'Video' do
       include_examples 'cumulative views'
     end
 
-    context 'given a SocketError' do
+    context 'given server errors' do
       let(:url) { 'https://www.facebook.com/video.php?v=1559182744389118' }
 
-      include_examples 'socket error'
+      include_examples 'server errors'
     end
   end
 end


### PR DESCRIPTION
These are some more errors that could occur when requesting HTML:
OpenSSL::SSL::SSLError
Errno::ETIMEDOUT
Errno::EHOSTUNREACH
Errno::ENETUNREACH
Errno::ECONNRESET
Net::OpenTimeout
SocketError

So we rescue them and raise `Funky::ConnectionError`