### PR TITLE
Replace video for cumulative view tests.

### DIFF
--- a/spec/videos/shared/examples.rb
+++ b/spec/videos/shared/examples.rb
@@ -27,7 +27,7 @@ end
 
 shared_examples 'cumulative views' do
   it 'only returns the views from this post (not cumulative ones)' do
-    expect(video.view_count).to be > 50_000_000
+    expect(video.view_count).to be > 6_000_000
   end
 end
 

--- a/spec/videos/video_spec.rb
+++ b/spec/videos/video_spec.rb
@@ -68,7 +68,7 @@ describe 'Video' do
     end
 
     context 'given a video ID with the cumulative views was passed' do
-      let(:video_id) { '203203106739575' }
+      let(:video_id) { '10153924745896633' }
 
       include_examples 'cumulative views'
     end
@@ -98,7 +98,7 @@ describe 'Video' do
     end
 
     context 'given a video url with cumulative views was passed' do
-      let(:url) { 'https://www.facebook.com/video.php?v=203203106739575' }
+      let(:url) { 'https://www.facebook.com/video.php?v=10153924745896633' }
 
       include_examples 'cumulative views'
     end


### PR DESCRIPTION
The previous video, 203203106739575, is no longer available.
So we have replaced it with the video, 10153924745896633. It's current
"views from this post" is just above 6,000,000 views.