### PR TITLE
Follow redirects when Facebook responds with 302

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.2.11 - 2017/01/19
+
+* [ENHANCEMENT] Follow redirects when Facebook responds with 302
+* [ENHANCEMENT] Parse new format of view count in Facebook HTML
+
 ## 0.2.10 - 2016/12/20
 
 * [ENHANCEMENT] Add a facebook page ID as a part of the Funky::Video API
@@ -13,7 +18,7 @@ For more information about changelogs, check
 
 ## 0.2.9 - 2016/12/13
 
-* [BUGFIX] Allow a video ID to be parsed out of facebook video URLs with 
+* [BUGFIX] Allow a video ID to be parsed out of facebook video URLs with
 trailing slashes.
 
 ## 0.2.8 - 2016/12/12

--- a/lib/funky/html/page.rb
+++ b/lib/funky/html/page.rb
@@ -16,9 +16,16 @@ module Funky
       def response_for(video_id)
         uri = uri_for video_id
         request = Net::HTTP::Get.new(uri.request_uri)
-        Net::HTTP.start(uri.host, 443, use_ssl: true) do |http|
+        response = Net::HTTP.start(uri.host, 443, use_ssl: true) do |http|
           http.request request
         end
+        if response.is_a? Net::HTTPRedirection
+          request = Net::HTTP::Get.new URI.parse(response.header['location'])
+          response = Net::HTTP.start(uri.host, 443, use_ssl: true) do |http|
+            http.request request
+          end
+        end
+        response
       rescue *server_errors => e
         raise ConnectionError, e.message
       end

--- a/lib/funky/html/parser.rb
+++ b/lib/funky/html/parser.rb
@@ -19,6 +19,7 @@ module Funky
       def extract_views_from(html)
         html.match(/<div><\/div><span class="fcg">\D*([\d,.]+)/)
         html.match %r{([\d,.]*?) views from this post} if $1.nil?
+        html.match /<div class=\"_1vx9\"><span>([\d,.]*?) Views<\/span><\/div>/ if $1.nil?
         matched_count $1
       end
 

--- a/lib/funky/version.rb
+++ b/lib/funky/version.rb
@@ -1,3 +1,3 @@
 module Funky
-  VERSION = "0.2.10"
+  VERSION = "0.2.11"
 end


### PR DESCRIPTION
Sometimes when requesting a video page with a URL like

https://www.facebook.com/video.php?v=1538251459532283

Facebook does not return a 200 OK, but a 302 and a new URL in the location header:

https://www.facebook.com/308524982504943/videos/1538251459532283

Also Facebook has a new possible format of outputting view count in the HTML.