### PR TITLE
Prevent URI#parse from raising error when Facebook issues a 302 redirect URL with spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@ For more information about changelogs, check
 
 ## 0.2.13 - 2017/01/25
 
-* [BUGFIX] When Facebook responds with a 302 redirect, sometimes an URL
-  with a space is returned (e.g., "https://www.facebook.com/KinoToPrzygoda /videos/322742591438587/") that is not URI encoded. This causes URI#parse to raise an InvalidURIError unless the URL is URL encoded.
+* [BUGFIX] Correctly fetch data for videos that belong to a Facebook page with a username that contains URL-unsafe characters. For instance "https://www.facebook.com/KinoToPrzygoda /" (with a space) is a valid Facebook page URL.
 
 
 ## 2017/01/24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.2.13 - 2017/01/25
+
+* [BUGFIX] Add URI encoding to URLs with spacing that need to be followed when
+  Facebook responds with a 302
+
+
 ## 2017/01/24
 
 * [ENHANCEMENT] Use 2.8 of Facebook Graph API (upgrade from 2.6).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,6 @@ For more information about changelogs, check
 ## 0.2.13 - 2017/01/25
 
 * [BUGFIX] Correctly fetch data for videos that belong to a Facebook page with a username that contains URL-unsafe characters. For instance "https://www.facebook.com/KinoToPrzygoda /" (with a space) is a valid Facebook page URL.
-
-
-## 2017/01/24
-
 * [ENHANCEMENT] Use 2.8 of Facebook Graph API (upgrade from 2.6).
 - There were deprecations in v2.8 of the Facebook Graph API as well as
 additions documented in [the changelog](https://developers.facebook.com/docs/apps/changelog).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ For more information about changelogs, check
 
 ## 0.2.13 - 2017/01/25
 
-* [BUGFIX] Add URI encoding to URLs with spacing that need to be followed when
-  Facebook responds with a 302
+* [BUGFIX] When Facebook responds with a 302 redirect, sometimes an URL
+  with a space is returned (e.g., "https://www.facebook.com/KinoToPrzygoda /videos/322742591438587/") that is not URI encoded. This causes URI#parse to raise an InvalidURIError unless the URL is URL encoded.
 
 
 ## 2017/01/24

--- a/lib/funky/html/page.rb
+++ b/lib/funky/html/page.rb
@@ -20,7 +20,7 @@ module Funky
           http.request request
         end
         if response.is_a? Net::HTTPRedirection
-          request = Net::HTTP::Get.new URI.parse(response.header['location'])
+          request = Net::HTTP::Get.new URI.parse(URI.encode(response.header['location']))
           response = Net::HTTP.start(uri.host, 443, use_ssl: true) do |http|
             http.request request
           end

--- a/lib/funky/version.rb
+++ b/lib/funky/version.rb
@@ -1,3 +1,3 @@
 module Funky
-  VERSION = "0.2.12"
+  VERSION = "0.2.13"
 end

--- a/spec/videos/video_spec.rb
+++ b/spec/videos/video_spec.rb
@@ -5,6 +5,7 @@ describe 'Video' do
   let(:existing_video_id) { '1042790765791228' }
   let(:unknown_video_id) { 'does-not-exist' }
   let(:another_video_id) { '903078593095780' }
+  let(:redirect_video_id) { '322742591438587' }
 
   describe '.where(id: video_ids)' do
     let(:videos) { Funky::Video.where(id: video_ids) }
@@ -59,6 +60,12 @@ describe 'Video' do
 
     context 'given an existing video ID was passed' do
       let(:video_id) { existing_video_id }
+
+      include_examples 'check id and counters'
+    end
+
+    context 'given a video ID that will cause a redirect is passed' do
+      let(:video_id) { redirect_video_id }
 
       include_examples 'check id and counters'
     end

--- a/spec/videos/video_spec.rb
+++ b/spec/videos/video_spec.rb
@@ -64,7 +64,7 @@ describe 'Video' do
       include_examples 'check id and counters'
     end
 
-    context 'given a video ID that will cause a redirect is passed' do
+    context 'give a video published by a page with a space in its username' do
       let(:video_id) { redirect_video_id }
 
       include_examples 'check id and counters'


### PR DESCRIPTION
- Certain video UUIDs cause a redirect (e.g., "322742591438587")
- These redirect URLs need to be encoded properly otherwise URI#parse
will not work