### PR TITLE
Fix Funky::Video#description method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.2.15 - 2017/03/21
+
+* [BUGFIX] Return a string for the description field of a Funky::Video
+  object even when the Facebook video has no description
+
 ## 0.2.14 - 2017/02/06
 
 * [ENHANCEMENT] Add the Funky::Page API to fetch name, username,

--- a/lib/funky/version.rb
+++ b/lib/funky/version.rb
@@ -1,3 +1,3 @@
 module Funky
-  VERSION = "0.2.14"
+  VERSION = "0.2.15"
 end

--- a/lib/funky/video.rb
+++ b/lib/funky/video.rb
@@ -18,7 +18,7 @@ module Funky
 
     # @return [String] the description of the video.
     def description
-      data[:description]
+      data[:description].to_s
     end
 
     # @return [Float] the length (duration) of the video.

--- a/spec/videos/video_spec.rb
+++ b/spec/videos/video_spec.rb
@@ -6,6 +6,7 @@ describe 'Video' do
   let(:unknown_video_id) { 'does-not-exist' }
   let(:another_video_id) { '903078593095780' }
   let(:redirect_video_id) { '322742591438587' }
+  let(:no_description_id) { '10154637916753090' }
 
   describe '.where(id: video_ids)' do
     let(:videos) { Funky::Video.where(id: video_ids) }
@@ -28,6 +29,13 @@ describe 'Video' do
       let(:video_ids) {unknown_video_id}
 
       it { expect(videos).to be_empty }
+    end
+
+    context 'given a video with no description' do
+      let(:video_ids) { no_description_id }
+      let(:video) {videos.first}
+
+      it { expect(video.description).to be_a(String) }
     end
 
     context 'given multiple existing video IDs were passed' do


### PR DESCRIPTION
Always have Funky::Video#description return a string, even when no
description field in the corresponding Facebook video exists