### PR TITLE
Add condition for the case of repeated timestamp 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.2.20 - 2017/04/20
+
+* [BUGFIX] Fix `Funky::Page#videos` by adding condition for an edge case.
+
 ## 0.2.19 - 2017/04/20
 
 * [IMPROVEMENT] Retry 3 times after a server error or a socket error, to fetch

--- a/lib/funky/connections/api.rb
+++ b/lib/funky/connections/api.rb
@@ -32,11 +32,15 @@ module Funky
             else
               Time.parse(json[:data][-1][:created_time]).to_i
             end
-          @try_count = 0
-          @previous_timestamp = timestamp
-          new_query = URI.decode_www_form(uri.query).to_h.merge('until' => timestamp)
-          uri.query = URI.encode_www_form(new_query)
-          json[:data] + fetch_multiple_pages(uri)
+          if @previous_timestamp == timestamp
+            []
+          else
+            @try_count = 0
+            @previous_timestamp = timestamp
+            new_query = URI.decode_www_form(uri.query).to_h.merge('until' => timestamp)
+            uri.query = URI.encode_www_form(new_query)
+            json[:data] + fetch_multiple_pages(uri)
+          end
         end
       end
 

--- a/lib/funky/version.rb
+++ b/lib/funky/version.rb
@@ -1,3 +1,3 @@
 module Funky
-  VERSION = "0.2.19"
+  VERSION = "0.2.20"
 end

--- a/spec/pages/videos_spec.rb
+++ b/spec/pages/videos_spec.rb
@@ -4,6 +4,7 @@ require 'pages/shared/examples'
 describe 'Page' do
   let(:fullscreen_page_id) { 'FullscreenInc' }
   let(:nextflix_page_id) { 'NetflixUS' }
+  let(:nbc_page_id) { 'NBC' }
 
   describe '#videos' do
     let(:page) { Funky::Page.find(page_id) }
@@ -40,6 +41,16 @@ describe 'Page' do
       # documentation of fetching pages with timestmap-based pagination.
       specify 'includes the oldest video of the page' do
         expect(videos.map {|v| v.id}).to include '68196585394'
+      end
+    end
+
+    context 'given another page with hundreds of videos' do
+      let(:page_id) { nbc_page_id }
+
+      # NOTE: This test fails if we only strictly followed the Facebook
+      # documentation of fetching pages with timestmap-based pagination.
+      specify 'includes the oldest video of the page' do
+        expect(videos.map {|v| v.id}).to include '10152197716420746'
       end
     end
 


### PR DESCRIPTION
this case happened for NBC videos. In time-based pagination, It had only one video in the last page (oldest video) and it shows even after we changed timestamp to date format.