### PR TITLE
Raise error in Page#find when it does not return a name of the page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.2.24 - 2017/05/10
+
+* [BUGFIX] Raise Funky::ContentNotFound error when a page does not return
+its name. This change will filter out cases a full url of website entered
+as page_id argument of `Funky::Page#find`, instead of username.
+
 ## 0.2.23 - 2017/05/09
 
 * [FEATURE] Print out logs for each pagination

--- a/lib/funky/page.rb
+++ b/lib/funky/page.rb
@@ -13,7 +13,7 @@ module Funky
     def self.find(page_id)
       page = Funky::Connection::API.fetch("#{page_id}?fields=name,username,location,fan_count,featured_video")
       if page[:name].nil?
-        raise ContentNotFound, "Sorry, page did not return its name field"
+        raise ContentNotFound, "Page not found with ID #{page_id}"
       else
         new(page)
       end

--- a/lib/funky/page.rb
+++ b/lib/funky/page.rb
@@ -12,7 +12,11 @@ module Funky
     # @return [Funky::Page] containing the data fetched by Facebook Graph API.
     def self.find(page_id)
       page = Funky::Connection::API.fetch("#{page_id}?fields=name,username,location,fan_count,featured_video")
-      new(page)
+      if page[:name].nil?
+        raise ContentNotFound, "Sorry, page did not return its name field"
+      else
+        new(page)
+      end
     end
 
     # Fetches data from Facebook Graph API and returns an array of Funky::Video

--- a/lib/funky/version.rb
+++ b/lib/funky/version.rb
@@ -1,3 +1,3 @@
 module Funky
-  VERSION = "0.2.23"
+  VERSION = "0.2.24"
 end

--- a/spec/pages/find_spec.rb
+++ b/spec/pages/find_spec.rb
@@ -4,6 +4,7 @@ require 'pages/shared/examples'
 describe 'Page' do
   let(:existing_page_id) { '1191441824276882' }
   let(:unknown_page_id) { 'does-not-exist' }
+  let(:website_url) { 'https://www.facebook.com/pg/FoxMovies/videos/?ref=page_internal' }
 
   describe '.find(page_id)' do
     let(:page) { Funky::Page.find(page_id) }
@@ -22,6 +23,12 @@ describe 'Page' do
       let(:page_id) { unknown_page_id }
 
       it { expect { page }.to raise_error(Funky::ContentNotFound) }
+    end
+
+    context 'given a website url was passed' do
+      let(:page_id) { website_url }
+
+      it { expect { page }.to raise_error Funky::ContentNotFound }
     end
   end
 end

--- a/spec/pages/videos_spec.rb
+++ b/spec/pages/videos_spec.rb
@@ -56,7 +56,7 @@ describe 'Page' do
 
     context 'given a request that raises' do
       let(:response) { Net::HTTPServerError.new nil, nil, nil }
-      let(:response_body) { '{}' }
+      let(:response_body) { '{"name":"Fullscreen"}' }
       before { expect(Net::HTTP).to receive(:start).once.and_return response }
       before { allow(response).to receive(:body).and_return response_body }
 


### PR DESCRIPTION
closes #87 