### PR TITLE
Fix order to find view count in HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.2.27 - 2017/08/28
+
+* [BUGFIX] Fetch the correct view count even for non-English pages
+
 ## 0.2.26 - 2017/06/06
 
 * [ENHANCEMENT] Raise ContentNotFound if Page#find is called with an invalid URI

--- a/lib/funky/html/parser.rb
+++ b/lib/funky/html/parser.rb
@@ -20,9 +20,9 @@ module Funky
 
       def extract_views_from(html)
         html.match(/<div><\/div><span class="fcg">\D*([\d,.]+)/)
+        html.match(/postViewCount:"([\d,.]*?)",/) if $1.nil?
         html.match %r{([\d,.]*?) views from this post} if $1.nil?
         html.match /<div class=\"_1vx9\"><span>([\d,.]*?) .*?<\/span><\/div>/ if $1.nil?
-        html.match(/postViewCount:"([\d,.]*?)",/) if $1.nil?
         matched_count $1
       end
 

--- a/lib/funky/version.rb
+++ b/lib/funky/version.rb
@@ -1,3 +1,3 @@
 module Funky
-  VERSION = "0.2.26"
+  VERSION = "0.2.27"
 end


### PR DESCRIPTION
Facebook is changing HTML structure again and now includes multiple
times "views from this post" in the HTML page for videos that are
not the current one. For instance check the HTML source code for
https://www.facebook.com/lhubkarong/videos/734072256763599/