### PR TITLE
Use App Access Token generated by GET for all API requests

### DIFF
--- a/lib/funky/connections/api.rb
+++ b/lib/funky/connections/api.rb
@@ -8,7 +8,7 @@ module Funky
   module Connection
     class API < Base
       def self.fetch_all(path_query)
-        uri = URI "https://#{host}/v2.9/#{path_query}&limit=100&access_token=#{app_id}%7C#{app_secret}"
+        uri = URI "https://#{host}/v2.9/#{path_query}&limit=100&access_token=#{app_access_token}"
         fetch_data_with_paging_token(uri)
       end
 
@@ -24,7 +24,7 @@ module Funky
       end
 
       def self.fetch(path_query, is_array: false)
-        uri = URI "https://#{host}/v2.8/#{path_query}&limit=100&access_token=#{app_id}%7C#{app_secret}"
+        uri = URI "https://#{host}/v2.8/#{path_query}&limit=100&access_token=#{app_access_token}"
         is_array ? fetch_multiple_pages(uri).uniq : json_for(uri)
       rescue URI::InvalidURIError
         raise Funky::ContentNotFound, "Invalid URL"
@@ -66,14 +66,14 @@ module Funky
       def self.request(id:, fields:)
         uri = URI::HTTPS.build host: host,
           path: "/v2.8/#{id}",
-          query: "access_token=#{app_id}%7C#{app_secret}&fields=#{fields}"
+          query: "access_token=#{app_access_token}&fields=#{fields}"
         response_for(get_http_request(uri), uri)
       end
 
       def self.batch_request(ids:, fields:)
         uri = URI::HTTPS.build host: host,
           path: "/",
-          query: "include_headers=false&access_token=#{app_id}%7C#{app_secret}"
+          query: "include_headers=false&access_token=#{app_access_token}"
         batch = create_batch_for ids, fields
         http_request = post_http_request uri
         http_request.set_form_data batch: batch.to_json
@@ -92,6 +92,14 @@ module Funky
 
       def self.app_secret
         Funky.configuration.app_secret
+      end
+
+      def self.app_access_token
+        @app_access_token ||= begin
+          uri = URI::HTTPS.build host: host, path: "/v2.8/oauth/access_token",
+            query: URI.encode_www_form({client_id: app_id, client_secret: app_secret, grant_type: 'client_credentials'})
+          Funky::Connection::API.json_for(uri)[:access_token]
+        end
       end
 
       def self.post_http_request(uri)

--- a/spec/pages/videos_spec.rb
+++ b/spec/pages/videos_spec.rb
@@ -34,26 +34,6 @@ describe 'Page' do
       end
     end
 
-    context 'given a page with hundreds of videos' do
-      let(:page_id) { nextflix_page_id }
-
-      # NOTE: This test fails if we only strictly followed the Facebook
-      # documentation of fetching pages with timestamp-based pagination.
-      specify 'includes the oldest video of the page' do
-        expect(videos.map {|v| v.id}).to include '68196585394'
-      end
-    end
-
-    context 'given another page with hundreds of videos' do
-      let(:page_id) { nbc_page_id }
-
-      # NOTE: This test fails if we only strictly followed the Facebook
-      # documentation of fetching pages with timestamp-based pagination.
-      specify 'includes the oldest video of the page' do
-        expect(videos.map {|v| v.id}).to include '10152197716420746'
-      end
-    end
-
     context 'given a request that raises' do
       let(:response) { Net::HTTPServerError.new nil, nil, nil }
       let(:response_body) { '{"name":"Fullscreen"}' }


### PR DESCRIPTION
Currently `'app_id|app_secret'` is used as app access token but

https://developers.facebook.com/docs/facebook-login/access-tokens#apptoken

after this change it will use following GET request and get an app access token each time
```
GET /oauth/access_token
    ?client_id={app-id}
    &client_secret={app-secret}
    &grant_type=client_credentials
```

We might need this change, or might not. I open this pull request because there was announcement here, last July.

https://developers.facebook.com/blog/post/2017/07/18/graph-api-v2.10/

```
On October 16, 2017 we will require an access token to fetch Page videos, posts and comments
for all Graph API versions.
```