### PR TITLE
raise Funky::VideoLoginRequired error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.2.32 - 2017/10/27
+
+* [FEATURE] Add `Funky::VideoLoginRequired` error to raise it when a video is
+restricted and needs log-in to view.
+
 ## 0.2.31 - 2017/10/25
 
 * [BUGFIX] Revert the change of version 0.2.29 and do not use request to get app

--- a/lib/funky/errors.rb
+++ b/lib/funky/errors.rb
@@ -1,4 +1,5 @@
 module Funky
   class ContentNotFound < StandardError; end
+  class VideoLoginRequired < StandardError; end
   class ConnectionError < StandardError; end
 end

--- a/lib/funky/html/page.rb
+++ b/lib/funky/html/page.rb
@@ -6,6 +6,9 @@ module Funky
         body = response_for(video_id).body
 
         if body.include? '<title id="pageTitle">Facebook</title>'
+          if body.include? 'content="Log In or Sign Up to View"'
+            raise VideoLoginRequired, 'Log in is required for viewing this video'
+          end
           raise ContentNotFound, 'Please double check the ID and try again.'
         else
           body

--- a/lib/funky/version.rb
+++ b/lib/funky/version.rb
@@ -1,3 +1,3 @@
 module Funky
-  VERSION = "0.2.31"
+  VERSION = "0.2.32"
 end

--- a/spec/videos/video_spec.rb
+++ b/spec/videos/video_spec.rb
@@ -3,6 +3,7 @@ require 'videos/shared/examples'
 
 describe 'Video' do
   let(:existing_video_id) { '1042790765791228' }
+  let(:restricted_video_id) { '1977533782517885' }
   let(:unknown_video_id) { 'does-not-exist' }
   let(:another_video_id) { '903078593095780' }
   let(:redirect_video_id) { '322742591438587' }
@@ -114,6 +115,11 @@ describe 'Video' do
       let(:video_id) { unknown_video_id }
 
       include_examples 'non-existing video'
+    end
+
+    context 'given a restricted video ID was passed' do
+      let(:video_id) { restricted_video_id }
+      it { expect {video}.to raise_error(Funky::VideoLoginRequired) }
     end
 
     context 'given a video ID with the cumulative views was passed' do


### PR DESCRIPTION
raise `VideoLoginRequired` error when login is required to view a video.