### PR TITLE
Add ActiveSupport instrumentation to Funky

### DIFF
--- a/lib/funky/connections/base.rb
+++ b/lib/funky/connections/base.rb
@@ -14,7 +14,7 @@ module Funky
         if defined?(ActiveSupport::Notifications)
           ActiveSupport::Notifications.instrument 'request.funky', data, &block
         else
-          yield data
+          block.call(data)
         end
       end
 


### PR DESCRIPTION
Adds support for ActiveSupport's instrumentation. Requests are
instrumented under the `request.funky` tag with uri, method, request and
response keys.