### PR TITLE
Correct video view count for some videos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.2.37 - 2019/07/23
+
+* [BUGFIX] Allow funky to scrape view count for more videos
+
 ## 0.2.36 - 2019/03/05
 
 * [BUGFIX] Fetch comment count, share count, like count for Facebook
@@ -14,8 +18,8 @@ videos with different HTML.
 ## 0.2.35 - 2019/01/14
 
 * [ENHANCEMENT] Use 2.10 of Facebook Graph API (upgrade from 2.8).
-- There will be deprecations in v2.8 of the Facebook Graph API soon. Check out [the changelog](https://developers.facebook.com/docs/apps/changelog).
-- Funky API is not changed. (Test is still passing)
+  - There will be deprecations in v2.8 of the Facebook Graph API soon. Check out [the changelog](https://developers.facebook.com/docs/apps/changelog).
+  - Funky API is not changed. (The same test is still passing)
 
 ## 0.2.34 - 2018/10/19
 

--- a/funky.gemspec
+++ b/funky.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "simplecov", "0.11.2"
-  spec.add_development_dependency "yard", "0.9.12"
+  spec.add_development_dependency "yard", "0.9.20"
   spec.add_development_dependency 'coveralls', "0.8.13"
 end

--- a/lib/funky/html/parser.rb
+++ b/lib/funky/html/parser.rb
@@ -24,6 +24,7 @@ module Funky
         html.match(/postViewCount:"([\d,.]*?)",/) if $1.nil?
         html.match /<div class=\"_1vx9\"><span>([\d,.]*?) .*?<\/span><\/div>/ if $1.nil?
         html.match /id=\"u_0_w\">([\d,.]*?) .*?<\/span><\/div>/ if $1.nil?
+        html.match />([\d,.]*?) Views<\/span><\/div>/ if $1.nil?
         html.match %r{([\d,.]*?) views from this post} if $1.nil?
         matched_count $1
       end

--- a/lib/funky/html/parser.rb
+++ b/lib/funky/html/parser.rb
@@ -22,8 +22,9 @@ module Funky
       def extract_views_from(html)
         html.match(/<div><\/div><span class="fcg">\D*([\d,.]+)/)
         html.match(/postViewCount:"([\d,.]*?)",/) if $1.nil?
-        html.match %r{([\d,.]*?) views from this post} if $1.nil?
         html.match /<div class=\"_1vx9\"><span>([\d,.]*?) .*?<\/span><\/div>/ if $1.nil?
+        html.match /id=\"u_0_w\">([\d,.]*?) .*?<\/span><\/div>/ if $1.nil?
+        html.match %r{([\d,.]*?) views from this post} if $1.nil?
         matched_count $1
       end
 

--- a/lib/funky/version.rb
+++ b/lib/funky/version.rb
@@ -1,3 +1,3 @@
 module Funky
-  VERSION = "0.2.36"
+  VERSION = "0.2.37"
 end


### PR DESCRIPTION
before
```rb
Funky::Video.find("2853274698022559")
#=> {:view_count=>258, :share_count=>7, :like_count=>18, :comment_count=>0}
```

after
```rb
Funky::Video.find("2853274698022559")
#=> {:view_count=>3545702, :share_count=>7, :like_count=>18, :comment_count=>0}
```